### PR TITLE
Версия 1.2.3.5

### DIFF
--- a/GeoLoader/Business/Client.cs
+++ b/GeoLoader/Business/Client.cs
@@ -12,8 +12,11 @@ namespace GeoLoader.Business
         WebClient client = new WebClient();
         private string cachePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                                                 "GeoLoader\\Cache");
+        
         public string DownloadString(string url)
         {
+            client.Encoding = System.Text.Encoding.UTF8;
+
             if (!Directory.Exists(cachePath))
             {
                 Directory.CreateDirectory(cachePath);

--- a/GeoLoader/Business/Loaders/GeoCacheLoader.cs
+++ b/GeoLoader/Business/Loaders/GeoCacheLoader.cs
@@ -59,7 +59,10 @@ namespace GeoLoader.Business.Loaders
             cache.PlacedById = int.Parse(nameMathResult.Groups[2].Value);
             cache.PlacedBy = nameMathResult.Groups[3].Value;
             cache.TypeCode = nameMathResult.Groups[4].Value;
-            var created = GetFieldValue("Создан", true);
+            var created = GetFieldValue("Создан", false);
+            if(created == "")
+                created = GetFieldValue("Опубликован", true); 
+            
             cache.PlacedDate = DateTime.ParseExact(created, "dd.MM.yyyy", CultureInfo.InvariantCulture);
             
             // Load log

--- a/GeoLoader/Properties/AssemblyInfo.cs
+++ b/GeoLoader/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.3.2")]
-[assembly: AssemblyFileVersion("1.2.3.2")]
+[assembly: AssemblyVersion("1.2.3.5")]
+[assembly: AssemblyFileVersion("1.2.3.5")]

--- a/GeoLoader/app.config
+++ b/GeoLoader/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <configuration>
     <configSections>
-        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-            <section name="GeoLoader.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="GeoLoader.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
         </sectionGroup>
     </configSections>
-<startup><supportedRuntime version="v2.0.50727"/></startup><userSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup><userSettings>
         <GeoLoader.Properties.Settings>
             <setting name="CacheExpirationInDays" serializeAs="String">
                 <value>3</value>


### PR DESCRIPTION
- добавлена поддержка UTF8
- если у тайника нет поля "Создан", то дата создания тайника берётся из поля "Опубликован"